### PR TITLE
Use multiple CSS class for counter container

### DIFF
--- a/textcounter.js
+++ b/textcounter.js
@@ -35,8 +35,9 @@
     };
 
     base.checkLimits = function(e) {
+      var countContainerClass = base.options.countContainerClass.split(' ').join('.');
       var $this = base.$el,
-          $countEl = $this.nextAll('.' + base.options.countContainerClass),
+          $countEl = $this.nextAll('.' + countContainerClass),
           $text = $this.val(),
           textCount = 0,
           textTotalCount = 0,
@@ -74,7 +75,7 @@
           base.options.max = max;
         }
         else {
-          base.$el.nextAll('.' + base.options.countContainerClass).text('error: [maxlength] attribute not set');
+          base.$el.nextAll('.' + countContainerClass).text('error: [maxlength] attribute not set');
         }
       }
 
@@ -158,14 +159,16 @@
 
     base.setCount = function(count) {
       var $this = base.$el,
-          $countEl = $this.nextAll('.' + base.options.countContainerClass);
+          countContainerClass = base.options.countContainerClass.split(' ').join('.'),
+          $countEl = $this.nextAll('.' + countContainerClass);
 
       $countEl.children('.' + base.options.textCountClass).text(count);
     };
 
     base.setErrors = function(type) {
       var $this = base.$el,
-          $countEl = $this.nextAll('.' + base.options.countContainerClass);
+          countContainerClass = base.options.countContainerClass.split(' ').join('.'),
+          $countEl = $this.nextAll('.' + countContainerClass);
 
       $this.addClass(base.options.inputErrorClass);
       $countEl.addClass(base.options.counterErrorClass);
@@ -188,7 +191,8 @@
 
     base.clearErrors = function(type) {
       var $this = base.$el,
-          $countEl = $this.nextAll('.' + base.options.countContainerClass);
+          countContainerClass = base.options.countContainerClass.split(' ').join('.'),
+          $countEl = $this.nextAll('.' + countContainerClass);
 
       $countEl.children('.error-text-' + type).remove();
 


### PR DESCRIPTION
If the key `countContainerClass` has multiple css classes, the jquery selectors fail.
