### PR TITLE
Added npm support for older code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "textcounter",
+	"title": "jQuery Text Counter",
+	"description": "jQuery plugin to count text/characters in a textarea or input. Allows error notifications on minimum or maximum number of characters/words.",
+	"keywords": [
+		"words",
+		"characters",
+		"counter",
+		"minimum",
+		"maximum"
+	],
+	"version": "0.2.0",
+	"author": {
+		"name": "ractoon",
+		"url": "http://www.ractoon.com"
+	},
+	"licenses": [
+	{
+		"type": "MIT",
+		"url": "https://github.com/ractoon/jQuery-Text-Counter/blob/master/LICENSE.md"
+	}
+	],
+	"bugs": "https://github.com/ractoon/jQuery-Text-Counter/issues",
+	"homepage": "https://github.com/ractoon/jQuery-Text-Counter",
+	"docs": "https://github.com/ractoon/jQuery-Text-Counter",
+	"dependencies": {
+		"jquery": ">=1.5"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,29 +1,26 @@
 {
-	"name": "textcounter",
-	"title": "jQuery Text Counter",
-	"description": "jQuery plugin to count text/characters in a textarea or input. Allows error notifications on minimum or maximum number of characters/words.",
-	"keywords": [
-		"words",
-		"characters",
-		"counter",
-		"minimum",
-		"maximum"
-	],
-	"version": "0.2.0",
-	"author": {
-		"name": "ractoon",
-		"url": "http://www.ractoon.com"
-	},
-	"licenses": [
-	{
-		"type": "MIT",
-		"url": "https://github.com/ractoon/jQuery-Text-Counter/blob/master/LICENSE.md"
-	}
-	],
-	"bugs": "https://github.com/ractoon/jQuery-Text-Counter/issues",
-	"homepage": "https://github.com/ractoon/jQuery-Text-Counter",
-	"docs": "https://github.com/ractoon/jQuery-Text-Counter",
-	"dependencies": {
-		"jquery": ">=1.5"
-	}
+  "name": "textcounter",
+  "version": "0.2.0",
+  "description": "jQuery plugin to count text/characters in a textarea or input. Allows error notifications on minimum or maximum number of characters/words.",
+  "main": "textcounter.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ractoon/jQuery-Text-Counter.git"
+  },
+  "author": {
+    "name": "ractoon",
+    "url": "https://www.ractoon.com"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/ractoon/jQuery-Text-Counter/blob/master/LICENSE.md"
+    }
+  ],
+  "bugs": "https://github.com/ractoon/jQuery-Text-Counter/issues",
+  "homepage": "https://github.com/ractoon/jQuery-Text-Counter",
+  "docs": "https://github.com/ractoon/jQuery-Text-Counter",
+  "dependencies": {
+    "jquery": ">=1.5"
+  }
 }


### PR DESCRIPTION
Enables users to add legacy code via npm (for version control/asset management). Technically this would be a patch for the 0.2.0 tag -- npm requires package.json (named exactly that) to function. I don't know of any workaround, so I hope this PR will be accepted so I can use the main npm repository...

Not sure if there's a preferred patch tagging system for this repo... I used the [patch tagging solution described in this stack overflow](https://stackoverflow.com/questions/40176739/how-should-you-create-a-patch-for-an-older-tag-in-source-control), specifically:

```
git checkout 0.2.0
git checkout -b v0_2_0-npm
// did the changes
git commit -m"Added npm support for older code."
git tag -a v0.2.0-npm -m"Added npm support."
git push origin v0_2_0-npm
git push --tags
```

Edit: I realize this can't be merged into master. I don't believe it's possible to submit a PR against a specific tag...